### PR TITLE
Fix inconsistent use of camelCase for test override payloads

### DIFF
--- a/lib/berbix.js
+++ b/lib/berbix.js
@@ -245,7 +245,7 @@ Client.prototype.updateTransaction = function (tokens, params) {
 
 Client.prototype.overrideTransaction = function (tokens, params) {
   const payload = {};
-  if (params.response_payload != null) {
+  if (params.responsePayload != null) {
     payload.response_payload = params.responsePayload;
   }
   if (params.flags != null) {


### PR DESCRIPTION
Should've been done in f932525d445be70f30d2e4986f34e647d1bdad64, but was unfortunately overlooked.