### PR TITLE
Add support and documentation for all hosted options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Supported options:
 - `phone` - Previously verified phone number for a user.
 - `customerUid` - An ID or identifier for the user in your system.
 - `templateKey` - The template key for this transaction.
+- `hostedOptions` - Optional configuration object for creating hosted transactions. The `hostedOptions` object can optionally include the following fields:
+  - `completionEmail` - Email address to which completion alerts will be sent for this transaction.
+  - `redirectUrl` - URL to redirect the user to after they complete the transaction. If not specified, the URL specified in the Berbix dashboard will be used instead.
 
 ##### `fetchTransaction(tokens: Tokens): object`
 

--- a/examples/transactions.js
+++ b/examples/transactions.js
@@ -24,7 +24,7 @@ var run = async function () {
       customerUid: "this is a customer uid",
       templateKey: "hi_6xP9A8y3Lzd2yoQFRRxlDZ_kqZAAP",
       hostedOptions: {
-        completion_email: "eric@berbix.com",
+        completionEmail: "eric@berbix.com",
       },
     });
   } catch (e) {

--- a/lib/berbix.js
+++ b/lib/berbix.js
@@ -174,7 +174,14 @@ Client.prototype.createTransaction = function (opts) {
     payload.template_key = opts.templateKey;
   }
   if (opts.hostedOptions != null) {
-    payload.hosted_options = opts.hostedOptions;
+    var hostedOptions = {};
+    if (opts.hostedOptions.completionEmail != null) {
+      hostedOptions.completion_email = opts.hostedOptions.completionEmail;
+    }
+    if (opts.hostedOptions.redirectUrl != null) {
+      hostedOptions.redirect_url = opts.hostedOptions.redirectUrl;
+    }
+    payload.hosted_options = hostedOptions;
   }
   return this._fetchTokens("/v0/transactions", payload);
 };


### PR DESCRIPTION
This PR adds documentation for the recently added `redirect_url` hosted transaction option. It also adds back-compatibility for the existing `completion_email` hosted transaction option. See [API reference](https://docs.berbix.com/reference#createtransaction).

This changed has been tested and confirmed to work as expected.

Note: I accidentally committed this straight to `master` in 3af743993f49c10d739fd3fe69792ca9a3bba7fb (reverted in 4d2b25c31c93c80b8b0ea582ed3f327d8599401b).
