### PR TITLE
Add support for API access to allow listed domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ Parameters:
 - `flags: string[]` - An optional list of flags to associate with the transaction (independent of the payload's contents), e.g. ["id_under_18", "id_under_21"]. See [our flags documentation](https://docs.berbix.com/docs/id-flags) for a list of flags.
 - `overrideFields: { string: string }` - An optional mapping from a [transaction field](https://docs.berbix.com/reference#gettransactionmetadata) to the desired override value, e.g. `params.overrideFields = { "date_of_birth": "2000-12-09" } `
 
+##### `fetchDomains(): object[]`
+
+Fetches all domains that are currently allowed to serve Berbix Verify for this account.
+
+##### `createDomain(domainName: string): object`
+
+Add a domain to the list of domains allowed to serve the Berbix Verify flow for this account.
+
+Parameters:
+
+- `domainName: string` The string representing the domain to add (which may contain wildcards) to the list of allowed domains.
+
+##### `deleteDomain(id: number): object`
+
+Delete a domain from the list of domains allowed to serve the Berbix Verify flow for this account.
+
+Parameters:
+
+- `id: number` The integer representing the ID of the domain (as returned from fetchDomains) to remove.
+
 ### `Tokens`
 
 #### Properties

--- a/lib/berbix.js
+++ b/lib/berbix.js
@@ -172,12 +172,7 @@ Client.prototype._fetchTokens = async function (path, payload) {
 };
 
 Client.prototype._createTransaction = async function (path, payload) {
-  var headers = {
-    Authorization:
-      "Basic " + new Buffer.from(`${this.apiSecret}:`).toString("base64"),
-    "User-Agent": "BerbixNode/" + SDK_VERSION,
-  };
-  var result = await this._request("POST", path, headers, payload);
+  var result = await this._basicAuthRequest("POST", path, payload);
   var tokens = new Tokens(
     result.refresh_token,
     result.access_token,
@@ -230,6 +225,15 @@ Client.prototype._refreshIfNecessary = async function (tokens) {
   }
 };
 
+Client.prototype._basicAuthRequest = async function (method, path, payload = null) {
+  var headers = {
+    Authorization:
+      "Basic " + new Buffer.from(`${this.apiSecret}:`).toString("base64"),
+    "User-Agent": "BerbixNode/" + SDK_VERSION,
+  };
+  return this._request(method, path, headers, payload);
+}
+
 Client.prototype._tokenAuthRequest = async function (
   method,
   tokens,
@@ -263,6 +267,23 @@ Client.prototype.updateTransaction = function (tokens, params) {
 
   return this._tokenAuthRequest("PATCH", tokens, "/v0/transactions", payload);
 };
+
+Client.prototype.fetchDomains = function() {
+  var domainsPromise = this._basicAuthRequest("GET", "/v0/domains");
+  async function domainsResp() {
+    var domainsRes = await domainsPromise
+    return domainsRes.domains;
+  }
+  return domainsResp();
+}
+
+Client.prototype.createDomain = function(domainName) {
+  return this._basicAuthRequest("POST", "/v0/domains", {"domain": domainName})
+}
+
+Client.prototype.deleteDomain = function(domainId) {
+  return this._basicAuthRequest("DELETE", `/v0/domains/${domainId}`)
+}
 
 Client.prototype.overrideTransaction = function (tokens, params) {
   const payload = {};


### PR DESCRIPTION
Add functions for using the recently released API routes for [GET, POST, and DELETE on allowed domains.](https://github.com/berbix/berbix/blob/26c8a9f64c00ca4ea3ec53a3456ccc440dbb1059/go/src/backend/routes/routes.go#L183)