### PR TITLE
Set version to 2.0.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "berbix",
-  "version": "1.0.0",
+  "version": "2.0.0-beta",
   "description": "Node SDK for interacting with the Berbix API",
   "main": "lib/berbix.js",
   "scripts": {


### PR DESCRIPTION
Missed setting this change in the 2.0.0 release. I'm going to remove the 2.0.0 tag and replace it with a 2.0.0-beta tag pointed at the commit on `master` for this merge for consistency