### PR TITLE
Bump to 2.0.0-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "berbix",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-rc2",
   "description": "Node SDK for interacting with the Berbix API",
   "main": "lib/berbix.js",
   "scripts": {


### PR DESCRIPTION
The commit that updated the version in `package.json` to `2.0.0-beta` came after the commit that was published as 2.0.0-beta. To keep the versions consistent, we can merge then publish this commit.